### PR TITLE
Add other name for network device

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Openhab 2.0.0
 # * configuration is injected
 #
-FROM java:8u45-jre
+FROM java:8u66-jre
 MAINTAINER Marcus of Wetware Labs <marcus@wetwa.re>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/files/boot.sh
+++ b/files/boot.sh
@@ -123,7 +123,7 @@ cp -n /opt/openhab/runtime/etc/logback_debug.xml $CONFIG_DIR/
 ######################
 # Decide how to launch
 
-ETH0_FOUND=`grep "eth0" /proc/net/dev`
+ETH0_FOUND=`grep "eth0\|enp0" /proc/net/dev`
 
 if [ -n "$ETH0_FOUND" ] ;
 then 

--- a/files/start.sh
+++ b/files/start.sh
@@ -6,8 +6,19 @@ cd `dirname $0`
 eclipsehome="runtime/server";
 
 # set ports for HTTP(S) server
-HTTP_PORT=${HTTP_PORT-8080}
-HTTPS_PORT=${HTTPS_PORT-8443}
+if [ ! -z ${OPENHAB_HTTP_PORT} ]
+then
+    HTTP_PORT=${OPENHAB_HTTP_PORT}
+else
+    HTTP_PORT=8080
+fi
+
+if [ ! -z ${OPENHAB_HTTPS_PORT} ]
+then
+    HTTPS_PORT=${OPENHAB_HTTPS_PORT}
+else
+    HTTPS_PORT=8443
+fi
 
 # get path to equinox jar inside $eclipsehome folder
 cp=$(find $eclipsehome -name "org.eclipse.equinox.launcher_*.jar" | sort | tail -1);
@@ -18,14 +29,15 @@ if [ -z "$cp" ]; then
 fi
 
 # program args
-prog_args="-Dlogback.configurationFile=./conf/logback.xml -DmdnsName=openhab -Dopenhab.logdir=./userdata/logs -Dsmarthome.servicecfg=./runtime/etc/services.cfg -Dsmarthome.servicepid=org.openhab -Dsmarthome.userdata=./userdata -Dorg.quartz.properties=./runtime/etc/quartz.properties -Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-ssl.xml,etc/jetty-deployer.xml,etc/jetty-https.xml,etc/jetty-selector.xml"
+prog_args="-Dlogback.configurationFile=./runtime/etc/logback.xml -DmdnsName=openhab -Dopenhab.logdir=./userdata/logs -Dsmarthome.servicecfg=./runtime/etc/services.cfg -Dsmarthome.servicepid=org.openhab -Dsmarthome.userdata=./userdata -Dorg.quartz.properties=./runtime/etc/quartz.properties -Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-ssl.xml,etc/jetty-deployer.xml,etc/jetty-https.xml,etc/jetty-selector.xml"
 
 echo Launching the openHAB runtime...
-exec java $prog_args \
+java $prog_args \
 	-Dosgi.clean=true \
 	-Declipse.ignoreApp=true \
 	-Dosgi.noShutdown=true \
 	-Djetty.home.bundle=org.openhab.io.jetty \
+	-Djetty.keystore.path=./runtime/etc/keystore \
 	-Dorg.osgi.service.http.port=$HTTP_PORT \
 	-Dorg.osgi.service.http.port.secure=$HTTPS_PORT \
 	-Dfelix.fileinstall.dir=addons \

--- a/files/start.sh
+++ b/files/start.sh
@@ -6,8 +6,8 @@ cd `dirname $0`
 eclipsehome="runtime/server";
 
 # set ports for HTTP(S) server
-HTTP_PORT=8080
-HTTPS_PORT=8443
+HTTP_PORT=${HTTP_PORT-8080}
+HTTPS_PORT=${HTTPS_PORT-8443}
 
 # get path to equinox jar inside $eclipsehome folder
 cp=$(find $eclipsehome -name "org.eclipse.equinox.launcher_*.jar" | sort | tail -1);


### PR DESCRIPTION
On my coreos cluster the networkdevice is called enp0. Don't know if there is any more universal way i linux so it don't depend on the hostos network device name. But this would fixit on coreos.
